### PR TITLE
Fix division by zero warning

### DIFF
--- a/src/TranslationServer/Command/MetricsCommand.php
+++ b/src/TranslationServer/Command/MetricsCommand.php
@@ -69,7 +69,7 @@ class MetricsCommand extends AbstractTranslationServerCommand
         foreach ($metrics as $language => $percentFinished) {
             $languageTranslations = $metrics[$language];
             $languageTranslationsMissing = $masterLanguageKeys - $languageTranslations;
-            $languageCompleted = round((100 / $masterLanguageKeys) * $languageTranslations, 2);
+            $languageCompleted = ($masterLanguageKeys) ? round((100 / $masterLanguageKeys) * $languageTranslations, 2) : 0;
             $this
                 ->printMessage(
                     $output,


### PR DESCRIPTION
When using domain filter I get this error

```
PHP Warning:  Division by zero in phar:///usr/local/bin/translation-server/src/TranslationServer/Command/MetricsCommand.php on line 72
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/translation-server:0
PHP   2. require() /usr/local/bin/translation-server:19
PHP   3. Symfony\Component\Console\Application->run() phar:///usr/local/bin/translation-server/bin/translation-server:25
PHP   4. Symfony\Component\Console\Application->doRun() phar:///usr/local/bin/translation-server/vendor/symfony/console/Application.php:120
PHP   5. Symfony\Component\Console\Application->doRunCommand() phar:///usr/local/bin/translation-server/vendor/symfony/console/Application.php:189
PHP   6. Symfony\Component\Console\Command\Command->run() phar:///usr/local/bin/translation-server/vendor/symfony/console/Application.php:838
PHP   7. Mmoreram\TranslationServer\Command\MetricsCommand->execute() phar:///usr/local/bin/translation-server/vendor/symfony/console/Command/Command.php:256
```

Just made a small patch to fix it
